### PR TITLE
Update alarms to only alarm when we are getting charged for extra

### DIFF
--- a/cloudwatch-ec2/variables.tf
+++ b/cloudwatch-ec2/variables.tf
@@ -5,6 +5,7 @@ variable "instances" {
     instance_type = string
     ami = string
     root_block_device = any
+    credit_specification = any
   }))
 }
 
@@ -43,4 +44,9 @@ variable "evaluation_periods" {
 variable "datapoints_to_alarm" {
   type = number
   default = 45
+}
+
+variable "credit_surplus_alarm_threshold" {
+  type = number
+  default = 0
 }


### PR DESCRIPTION
With the t3 unlimited instances we are running now we are triggering alarms when we run out of built up credit balance. However unlike t2 instances, the t3 unlimited instances don't slow down in this case, they just go into a credit deficit. If this credit deficit persists for 24 hours we get charged extra, if not the credits just build back up. Instead of getting alarms for these instances when the credit bank is empty instead set an alarm when we are getting charged extra. In that case we may want to reevaluate the instance size.

Unlimited described here: 
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-unlimited-mode-concepts.html